### PR TITLE
add oauth when jwt subject is available

### DIFF
--- a/examples/rails/Gemfile
+++ b/examples/rails/Gemfile
@@ -41,4 +41,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem "firetail", "~> 1.0.1"
+gem "firetail", '~> 1.0.1'

--- a/examples/rails/Gemfile.lock
+++ b/examples/rails/Gemfile.lock
@@ -60,8 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     async (1.30.3)
       console (~> 1.10)
       nio4r (~> 2.3)
@@ -76,9 +76,9 @@ GEM
       openapi_parser (~> 2.1.0)
       rack (>= 1.5)
     concurrent-ruby (1.2.2)
-    console (1.24.0)
+    console (1.25.2)
       fiber-annotation
-      fiber-local
+      fiber-local (~> 1.1)
       json
     crass (1.0.6)
     date (3.3.3)
@@ -86,7 +86,9 @@ GEM
     erubi (1.12.0)
     ffi (1.15.5)
     fiber-annotation (0.2.0)
-    fiber-local (1.0.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (0.1.2)
     firetail (1.0.1)
       async (~> 1.30.3)
       committee_firetail (~> 5.0.1)
@@ -100,7 +102,7 @@ GEM
     json-schema (3.0.0)
       addressable (>= 2.8)
     json_schema (0.21.0)
-    jwt (2.8.1)
+    jwt (2.8.2)
       base64
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -133,7 +135,7 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     openapi_parser (2.1.0)
-    public_suffix (5.0.5)
+    public_suffix (6.0.0)
     puma (5.6.6)
       nio4r (~> 2.0)
     racc (1.7.3)

--- a/lib/firetail.rb
+++ b/lib/firetail.rb
@@ -154,6 +154,7 @@ module Firetail
       else
         body = body.body
       end
+      
       @reqres.push({
 	version: "1.0.0-alpha",
 	dateCreated: Time.now.utc.to_i,
@@ -171,10 +172,14 @@ module Firetail
   	  statusCode: status,
 	  body: body,
           headers: response_headers,
-	}
-      })
+       },
+       oauth: subject ? {
+         subject: sha1_hash(subject),
+       } : nil,
+      }.compact) # .compact removes keys with nil values, so we avoid sending empty values
       @request.body.rewind
       #Firetail.logger.debug "Request: #{body}"
+      #Firetail.logger.debug "Request: #{@reqres}"
 
       # the time we calculate if request that is
       # buffered max is 120 seconds


### PR DESCRIPTION
## Describe your changes
* Previously we remove including OAuth information as it always send oauth JWT Subject even though the user token does not exist, causing failure to send logging to firetail.

This PR adds it back and ensure that all keys with empty (nil) values are discarded.

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have resolved any merge conflicts
- [ ] I have run tests locally and they pass
- [ ] I have linted and auto-formatted the code
- [ ] If there is new or changed functionality, I have added/updated the tests
- [ ] If there is new or changed functionality, I have added/updated the documentation
